### PR TITLE
Fix blocked substitution slot after player is sent off (#7)

### DIFF
--- a/websoccer/classes/SimulationHelper.class.php
+++ b/websoccer/classes/SimulationHelper.class.php
@@ -155,64 +155,81 @@ class SimulationHelper {
 		}
 		
 		foreach ($substitutions as $substitution) {
-			if ($substitution->minute == $match->minute 
-					&& !isset($team->removedPlayers[$substitution->playerOut->id])
-					&& isset($team->playersOnBench[$substitution->playerIn->id])) {
+			if ($substitution->minute != $match->minute) {
+				continue;
+			}
+
+			// the substitution can never be executed if the player to substitute is not on the pitch anymore,
+			// e.g. because he has been sent off after his second yellow card (see issue #7) or has already
+			// been substituted by an unplanned substitution.
+			// Mark the minute as unreachable, so that the manager can plan a new substitution for this slot
+			// and so that it can be replaced by an unplanned substitution.
+			// Do not simply remove it, because it might become out of sync with DB table entry on state saving.
+			if (isset($team->removedPlayers[$substitution->playerOut->id])) {
+				$substitution->minute = 999;
+				continue;
+			}
+
+			// the substitution can also never be executed if the player to come in is not on the bench anymore,
+			// e.g. because he has already entered the pitch through an earlier substitution.
+			if (!isset($team->playersOnBench[$substitution->playerIn->id])) {
+				$substitution->minute = 999;
+				continue;
+			}
+
+			// check condition
+			if ($substitution->condition == SUB_CONDITION_TIE && $match->homeTeam->getGoals() != $match->guestTeam->getGoals()
+					|| $substitution->condition == SUB_CONDITION_LEADING && $team->getGoals() <= self::getOpponentTeamOfTeam($team, $match)->getGoals()
+					|| $substitution->condition == SUB_CONDITION_DEFICIT && $team->getGoals() >= self::getOpponentTeamOfTeam($team, $match)->getGoals()) {
+				// set minute as unreachable, so that it could be replaced by an unplanned substitution.
+				// do not simply remove it, because it might become out of sync with DB table entry on state saving.
+				$substitution->minute = 999;
+				continue;
+			}
 				
-				// check condition
-				if ($substitution->condition == SUB_CONDITION_TIE && $match->homeTeam->getGoals() != $match->guestTeam->getGoals()
-						|| $substitution->condition == SUB_CONDITION_LEADING && $team->getGoals() <= self::getOpponentTeamOfTeam($team, $match)->getGoals()
-						|| $substitution->condition == SUB_CONDITION_DEFICIT && $team->getGoals() >= self::getOpponentTeamOfTeam($team, $match)->getGoals()) {
-					// set minute as unreachable, so that it could be replaced by an unplanned substitution.
-					// do not simply remove it, because it might become out of sync with DB table entry on state saving.
-					$substitution->minute = 999;
-					continue;
-				}
-				
-				$team->removePlayer($substitution->playerOut);
-				
-				// determine main position.
-				// first: is it specified at substition config?
-				// second: has the player a main position? Note that youth players have main position "-"
-				// third: add player to his general position, without any main position
-				if (strlen($substitution->position)) {
-					$mainPosition = $substitution->position;
-				} else if (strlen($substitution->playerIn->mainPosition) && $substitution->playerIn->mainPosition != "-") {
-					$mainPosition = $substitution->playerIn->mainPosition;
-				} else {
-					$mainPosition = NULL;
-				}
-				
-				// determine general position
-				if ($mainPosition == NULL) {
-					$position = $substitution->playerIn->position;
-				} else {
-					$positionMapping = self::getPositionsMapping();
-					$position = $positionMapping[$mainPosition];
-				}
-				
-				// strength deduction needed?
-				$strength = $substitution->playerIn->strength;
-				if ($position != $substitution->playerIn->position) {
-					$strength = round($strength * (1 - WebSoccer::getInstance()->getConfig("sim_strength_reduction_wrongposition") / 100));
-				} else if ($mainPosition != NULL && $mainPosition != $substitution->playerIn->mainPosition) {
-					$strength = round($strength * (1 - WebSoccer::getInstance()->getConfig("sim_strength_reduction_secondary") / 100));
-				}
-				
-				// updates values
-				$substitution->playerIn->position = $position;
-				$substitution->playerIn->strength = $strength;
-				$substitution->playerIn->mainPosition = $mainPosition;
-				
-				// add to playground
-				$team->positionsAndPlayers[$substitution->playerIn->position][] = $substitution->playerIn;
-				
-				// remove from bench
-				unset($team->playersOnBench[$substitution->playerIn->id]);
-				
-				foreach ($observers as $observer) {
-					$observer->onSubstitution($match, $substitution);
-				}
+			$team->removePlayer($substitution->playerOut);
+
+			// determine main position.
+			// first: is it specified at substition config?
+			// second: has the player a main position? Note that youth players have main position "-"
+			// third: add player to his general position, without any main position
+			if ($substitution->position != NULL && strlen($substitution->position)) {
+				$mainPosition = $substitution->position;
+			} else if (strlen($substitution->playerIn->mainPosition) && $substitution->playerIn->mainPosition != "-") {
+				$mainPosition = $substitution->playerIn->mainPosition;
+			} else {
+				$mainPosition = NULL;
+			}
+
+			// determine general position
+			if ($mainPosition == NULL) {
+				$position = $substitution->playerIn->position;
+			} else {
+				$positionMapping = self::getPositionsMapping();
+				$position = $positionMapping[$mainPosition];
+			}
+
+			// strength deduction needed?
+			$strength = $substitution->playerIn->strength;
+			if ($position != $substitution->playerIn->position) {
+				$strength = round($strength * (1 - WebSoccer::getInstance()->getConfig("sim_strength_reduction_wrongposition") / 100));
+			} else if ($mainPosition != NULL && $mainPosition != $substitution->playerIn->mainPosition) {
+				$strength = round($strength * (1 - WebSoccer::getInstance()->getConfig("sim_strength_reduction_secondary") / 100));
+			}
+
+			// updates values
+			$substitution->playerIn->position = $position;
+			$substitution->playerIn->strength = $strength;
+			$substitution->playerIn->mainPosition = $mainPosition;
+
+			// add to playground
+			$team->positionsAndPlayers[$substitution->playerIn->position][] = $substitution->playerIn;
+
+			// remove from bench
+			unset($team->playersOnBench[$substitution->playerIn->id]);
+
+			foreach ($observers as $observer) {
+				$observer->onSubstitution($match, $substitution);
 			}
 		}
 	}
@@ -334,14 +351,26 @@ class SimulationHelper {
 			$index++;
 		}
 		
-		// otherwise replace first sub you can find that has not been executed
+		// otherwise replace an unreachable substitution (minute 999), since it will never be executed
+		// anyway (e.g. because its player has been sent off after a yellow-red card, see issue #7)
+		$index = 0;
+		foreach ($team->substitutions as $existingSub) {
+			if ($existingSub->minute == 999) {
+				$team->substitutions[$index] = $substitution;
+				return TRUE;
+			}
+
+			$index++;
+		}
+
+		// then replace first sub you can find that has not been executed
 		$index = 0;
 		foreach ($team->substitutions as $existingSub) {
 			if ($existingSub->minute > $minute) {
 				$team->substitutions[$index] = $substitution;
 				return TRUE;
 			}
-					
+
 			$index++;
 		}
 		 

--- a/websoccer/tests/Unit/SimulationHelperTest.php
+++ b/websoccer/tests/Unit/SimulationHelperTest.php
@@ -233,6 +233,9 @@ final class SimulationHelperTest extends TestCaseBase {
 		$observer->expects($this->never())->method('onSubstitution');
 
 		SimulationHelper::checkAndExecuteSubstitutions($match, $home, [$observer]);
+
+		// the substitution slot must be freed, since the substitution will never be executed (see issue #7).
+		$this->assertSame(999, $sub->minute);
 	}
 
 	public function testCheckAndExecuteSubstitutionsSkipsWhenPlayerNotOnBench(): void {
@@ -252,6 +255,202 @@ final class SimulationHelperTest extends TestCaseBase {
 		$observer->expects($this->never())->method('onSubstitution');
 
 		SimulationHelper::checkAndExecuteSubstitutions($match, $home, [$observer]);
+
+		// the substitution slot must be freed, since the substitution will never be executed (see issue #7).
+		$this->assertSame(999, $sub->minute);
+	}
+
+	/**
+	 * Issue #7: a player who got sent off the pitch after his second yellow card cannot be
+	 * substituted anymore. The planned substitution must not be executed, but its slot must be
+	 * freed (marked as unreachable) so that the manager can still plan another substitution.
+	 *
+	 * @see https://github.com/ihofmann/open-websoccer/issues/7
+	 */
+	public function testSubstitutionForPlayerSentOffAfterSecondYellowCardIsNotExecutedAndSlotIsFreed(): void {
+		$home = new SimulationTeam(1, 50);
+		$guest = new SimulationTeam(2, 50);
+		$match = new SimulationMatch(1, $home, $guest, 55);
+
+		// player on the pitch for whom a substitution is planned at minute 60.
+		$out = $this->makePlayer(1, PLAYER_POSITION_MIDFIELD, 80, $home);
+		$home->positionsAndPlayers[PLAYER_POSITION_MIDFIELD][] = $out;
+
+		// player on the bench who is supposed to come in.
+		$in = new SimulationPlayer(2, $home, PLAYER_POSITION_MIDFIELD, 'ZM', 3.0, 25, 75, 70, 60, 90, 85);
+		$home->playersOnBench[2] = $in;
+
+		$sub = new SimulationSubstitution(60, $in, $out);
+		$home->substitutions = [$sub];
+
+		$observer = new DefaultSimulationObserver();
+
+		// first yellow card: the player may stay on the pitch, so the substitution is still possible.
+		$observer->onYellowCard($match, $out);
+		$this->assertSame(1, $out->yellowCards);
+		$this->assertFalse(isset($home->removedPlayers[1]));
+
+		// second yellow card: the player is sent off, so his planned substitution can never be executed.
+		$observer->onYellowCard($match, $out);
+		$this->assertSame(2, $out->yellowCards);
+		$this->assertTrue(isset($home->removedPlayers[1]));
+
+		$observerMock = $this->createMock(\ISimulatorObserver::class);
+		$observerMock->expects($this->never())->method('onSubstitution');
+
+		// the planned substitution minute is reached.
+		$match->minute = 60;
+		SimulationHelper::checkAndExecuteSubstitutions($match, $home, [$observerMock]);
+
+		// the substitution must not be executed.
+		$this->assertTrue(isset($home->playersOnBench[2]));
+
+		// but it must be marked as unreachable, so that the slot does not remain blocked forever.
+		$this->assertSame(999, $sub->minute);
+	}
+
+	/**
+	 * A single yellow card does not send a player off, so a planned substitution
+	 * for him must be executed as usual (see issue #7).
+	 */
+	public function testSingleYellowCardDoesNotPreventPlannedSubstitution(): void {
+		\WebSoccer::setInstanceForTesting($this->mockWebsoccer([
+			'sim_strength_reduction_wrongposition' => 10,
+			'sim_strength_reduction_secondary' => 5,
+		]));
+
+		$home = new SimulationTeam(1, 50);
+		$guest = new SimulationTeam(2, 50);
+		$match = new SimulationMatch(1, $home, $guest, 59);
+
+		$out = $this->makePlayer(1, PLAYER_POSITION_MIDFIELD, 80, $home);
+		$home->positionsAndPlayers[PLAYER_POSITION_MIDFIELD][] = $out;
+
+		$in = new SimulationPlayer(2, $home, PLAYER_POSITION_MIDFIELD, 'ZM', 3.0, 25, 75, 70, 60, 90, 85);
+		$home->playersOnBench[2] = $in;
+
+		$sub = new SimulationSubstitution(60, $in, $out);
+		$home->substitutions = [$sub];
+
+		// first yellow card only: the player stays on the pitch.
+		(new DefaultSimulationObserver())->onYellowCard($match, $out);
+
+		$match->minute = 60;
+		SimulationHelper::checkAndExecuteSubstitutions($match, $home, []);
+
+		// the substitution is executed as planned.
+		$this->assertTrue(isset($home->removedPlayers[1]));
+		$this->assertFalse(isset($home->playersOnBench[2]));
+		$this->assertContains($in, $home->positionsAndPlayers[$in->position]);
+		$this->assertSame(60, $sub->minute);
+	}
+
+	/**
+	 * Issue #7: if the player who is supposed to come in is not on the bench anymore
+	 * (e.g. because he entered the pitch through an earlier substitution), the planned
+	 * substitution must not be executed, but its slot must be freed.
+	 *
+	 * @see https://github.com/ihofmann/open-websoccer/issues/7
+	 */
+	public function testSubstitutionWithPlayerInNotOnBenchAnymoreIsNotExecutedAndSlotIsFreed(): void {
+		\WebSoccer::setInstanceForTesting($this->mockWebsoccer([
+			'sim_strength_reduction_wrongposition' => 10,
+			'sim_strength_reduction_secondary' => 5,
+		]));
+
+		$home = new SimulationTeam(1, 50);
+		$guest = new SimulationTeam(2, 50);
+		$match = new SimulationMatch(1, $home, $guest, 30);
+
+		$a = $this->makePlayer(1, PLAYER_POSITION_MIDFIELD, 80, $home);
+		$home->positionsAndPlayers[PLAYER_POSITION_MIDFIELD][] = $a;
+		$c = $this->makePlayer(3, PLAYER_POSITION_DEFENCE, 80, $home);
+		$home->positionsAndPlayers[PLAYER_POSITION_DEFENCE][] = $c;
+
+		$b = new SimulationPlayer(2, $home, PLAYER_POSITION_MIDFIELD, 'ZM', 3.0, 25, 75, 70, 60, 90, 85);
+		$home->playersOnBench[2] = $b;
+
+		// valid substitution at minute 30: A goes out, B comes in.
+		$firstSub = new SimulationSubstitution(30, $b, $a);
+		// invalid substitution at minute 60: B is already on the pitch since minute 30.
+		$secondSub = new SimulationSubstitution(60, $b, $c);
+		$home->substitutions = [$firstSub, $secondSub];
+
+		// minute 30: the first substitution is executed.
+		$match->minute = 30;
+		SimulationHelper::checkAndExecuteSubstitutions($match, $home, []);
+		$this->assertTrue(isset($home->removedPlayers[1]));
+		$this->assertFalse(isset($home->playersOnBench[2]));
+
+		// minute 60: the second substitution cannot be executed anymore.
+		$match->minute = 60;
+		SimulationHelper::checkAndExecuteSubstitutions($match, $home, []);
+		$this->assertFalse(isset($home->removedPlayers[3]));
+
+		// but it must be marked as unreachable, so that the slot does not remain blocked forever.
+		$this->assertSame(999, $secondSub->minute);
+	}
+
+	/**
+	 * Issue #7: a planned substitution which became unreachable (because its player was sent off
+	 * after a yellow-red card) must be the first one to be replaced by an unplanned substitution
+	 * (e.g. after an injury), rather than destroying a still valid planned substitution.
+	 *
+	 * @see https://github.com/ihofmann/open-websoccer/issues/7
+	 */
+	public function testUnplannedSubstitutionReplacesUnreachablePlannedSubstitutionBeforeValidOnes(): void {
+		$home = new SimulationTeam(1, 50);
+		$guest = new SimulationTeam(2, 50);
+		$match = new SimulationMatch(1, $home, $guest, 55);
+
+		// player who will be sent off after his second yellow card, with a planned substitution at minute 60.
+		$out = $this->makePlayer(1, PLAYER_POSITION_MIDFIELD, 80, $home);
+		$home->positionsAndPlayers[PLAYER_POSITION_MIDFIELD][] = $out;
+		$benchPlayer = new SimulationPlayer(2, $home, PLAYER_POSITION_STRIKER, 'MS', 3.0, 25, 75, 70, 60, 90, 85);
+		$home->playersOnBench[2] = $benchPlayer;
+		$deadSub = new SimulationSubstitution(60, $benchPlayer, $out);
+
+		// two more, still valid planned substitutions in the future.
+		$x = $this->makePlayer(3, PLAYER_POSITION_DEFENCE, 80, $home);
+		$home->positionsAndPlayers[PLAYER_POSITION_DEFENCE][] = $x;
+		$y = $this->makePlayer(4, PLAYER_POSITION_DEFENCE, 80, $home);
+		$home->positionsAndPlayers[PLAYER_POSITION_DEFENCE][] = $y;
+		$benchC = new SimulationPlayer(5, $home, PLAYER_POSITION_STRIKER, 'MS', 3.0, 25, 75, 70, 60, 90, 85);
+		$home->playersOnBench[5] = $benchC;
+		$benchD = new SimulationPlayer(6, $home, PLAYER_POSITION_STRIKER, 'MS', 3.0, 25, 75, 70, 60, 90, 85);
+		$home->playersOnBench[6] = $benchD;
+		$validSub1 = new SimulationSubstitution(75, $benchC, $x);
+		$validSub2 = new SimulationSubstitution(80, $benchD, $y);
+
+		$home->substitutions = [$deadSub, $validSub1, $validSub2];
+
+		// the player is sent off after his second yellow card.
+		$observer = new DefaultSimulationObserver();
+		$observer->onYellowCard($match, $out);
+		$observer->onYellowCard($match, $out);
+
+		// at minute 60, his planned substitution is skipped and thus becomes unreachable.
+		$match->minute = 60;
+		SimulationHelper::checkAndExecuteSubstitutions($match, $home, []);
+		$this->assertSame(999, $deadSub->minute);
+
+		// at minute 65, another player gets injured and needs to be substituted.
+		$match->minute = 65;
+		$injured = $this->makePlayer(7, PLAYER_POSITION_MIDFIELD, 80, $home);
+		$home->positionsAndPlayers[PLAYER_POSITION_MIDFIELD][] = $injured;
+		$benchE = new SimulationPlayer(8, $home, PLAYER_POSITION_MIDFIELD, 'ZM', 3.0, 25, 75, 70, 60, 90, 85);
+		$home->playersOnBench[8] = $benchE;
+
+		$result = SimulationHelper::createUnplannedSubstitutionForPlayer(66, $injured);
+		$this->assertTrue($result);
+
+		// the unplanned substitution replaces the unreachable one...
+		$this->assertSame($benchE, $home->substitutions[0]->playerIn);
+		$this->assertSame($injured, $home->substitutions[0]->playerOut);
+		$this->assertSame(66, $home->substitutions[0]->minute);
+		// ...while the still valid planned substitutions remain untouched.
+		$this->assertSame($validSub1, $home->substitutions[1]);
+		$this->assertSame($validSub2, $home->substitutions[2]);
 	}
 
 	public function testCreateUnplannedSubstitutionReturnsFalseWithEmptyBench(): void {

--- a/websoccer/tests/Unit/SimulationHelperTest.php
+++ b/websoccer/tests/Unit/SimulationHelperTest.php
@@ -398,6 +398,86 @@ final class SimulationHelperTest extends TestCaseBase {
 	 *
 	 * @see https://github.com/ihofmann/open-websoccer/issues/7
 	 */
+	/**
+	 * Issue #7, exactly as reported by the user: a player with a (single) yellow card was not
+	 * substituted although a substitution was planned for him; the slot remained marked as used.
+	 *
+	 * This test documents that the yellow card itself never prevents the substitution (see also
+	 * testSingleYellowCardDoesNotPreventPlannedSubstitution). The real-world trigger for the reported
+	 * symptom is that the planned bench player is no longer available at the planned minute, e.g.
+	 * because he entered the pitch through an earlier injury substitution. In that case the skipped
+	 * substitution must free its slot (minute 999), so that the manager can still plan and execute
+	 * a new substitution for the booked player.
+	 *
+	 * @see https://github.com/ihofmann/open-websoccer/issues/7
+	 */
+	public function testBookedPlayerIsSubstitutedAfterSlotIsFreedWhenBenchPlayerWasConsumedByInjurySub(): void {
+		\WebSoccer::setInstanceForTesting($this->mockWebsoccer([
+			'sim_strength_reduction_wrongposition' => 10,
+			'sim_strength_reduction_secondary' => 5,
+		]));
+
+		$home = new SimulationTeam(1, 50);
+		$guest = new SimulationTeam(2, 50);
+		$match = new SimulationMatch(1, $home, $guest, 50);
+
+		// booked player (single yellow card) whom the manager wants to substitute in order to
+		// protect him from a yellow-red card.
+		$booked = $this->makePlayer(1, PLAYER_POSITION_MIDFIELD, 80, $home);
+		$booked->yellowCards = 1;
+		$home->positionsAndPlayers[PLAYER_POSITION_MIDFIELD][] = $booked;
+
+		// another midfielder on the pitch who will get injured.
+		$c = $this->makePlayer(3, PLAYER_POSITION_MIDFIELD, 80, $home);
+		$home->positionsAndPlayers[PLAYER_POSITION_MIDFIELD][] = $c;
+
+		// bench players: B is the planned player to come in, E remains available.
+		$b = new SimulationPlayer(2, $home, PLAYER_POSITION_MIDFIELD, 'ZM', 3.0, 25, 75, 70, 60, 90, 85);
+		$home->playersOnBench[2] = $b;
+		$e = new SimulationPlayer(8, $home, PLAYER_POSITION_MIDFIELD, 'ZM', 3.0, 25, 75, 70, 60, 90, 85);
+		$home->playersOnBench[8] = $e;
+
+		// planned substitution for the booked player at minute 60.
+		$plannedSub = new SimulationSubstitution(60, $b, $booked);
+		$home->substitutions = [$plannedSub];
+
+		$observer = new DefaultSimulationObserver();
+
+		// minute 50: teammate C gets injured. The injury substitution automatically consumes
+		// bench player B (first midfielder on the bench) for minute 51.
+		$observer->onInjury($match, $c, 2);
+		$this->assertCount(2, $home->substitutions);
+		$this->assertSame(51, $home->substitutions[1]->minute);
+
+		// minute 51: the injury substitution is executed; B is now on the pitch.
+		$match->minute = 51;
+		SimulationHelper::checkAndExecuteSubstitutions($match, $home, []);
+		$this->assertTrue(isset($home->removedPlayers[3]));
+		$this->assertFalse(isset($home->playersOnBench[2]));
+
+		// minute 60: the planned substitution for the booked player cannot be executed anymore,
+		// because B is not on the bench. The booked player himself is still on the pitch
+		// (a single yellow card never prevents a substitution).
+		$match->minute = 60;
+		SimulationHelper::checkAndExecuteSubstitutions($match, $home, []);
+		$this->assertFalse(isset($home->removedPlayers[1]));
+
+		// the slot is freed, so the manager can plan a new substitution (here: E comes in).
+		$this->assertSame(999, $plannedSub->minute);
+
+		// the manager plans a new substitution for the booked player, as the live match changes
+		// page allows after the slot has been freed.
+		$newSub = new SimulationSubstitution(70, $e, $booked);
+		$home->substitutions = [$newSub];
+
+		// minute 70: the booked player is finally substituted.
+		$match->minute = 70;
+		SimulationHelper::checkAndExecuteSubstitutions($match, $home, []);
+		$this->assertTrue(isset($home->removedPlayers[1]));
+		$this->assertFalse(isset($home->playersOnBench[8]));
+		$this->assertContains($e, $home->positionsAndPlayers[$e->position]);
+	}
+
 	public function testUnplannedSubstitutionReplacesUnreachablePlannedSubstitutionBeforeValidOnes(): void {
 		$home = new SimulationTeam(1, 50);
 		$guest = new SimulationTeam(2, 50);


### PR DESCRIPTION
Fixes #7.

## Problem

As reported in issue #7, a planned substitution was never executed, but its slot was still treated as used, so the manager could not plan another substitution during the live match. (The reporter suspected a single yellow card as the trigger. Unit tests in this PR document that a single booking does not affect substitutions at all - the real triggers are the ones below.)

A planned substitution is skipped by `SimulationHelper::checkAndExecuteSubstitutions()` when it becomes unexecutable, e.g. when:

- the player to be substituted has been sent off after his **second** yellow card (yellow-red) before the planned minute, or
- the player to come in is no longer on the bench, e.g. because he already entered the pitch through an earlier (injury) substitution.

Previously, such a skipped substitution kept its planned minute. Both `SaveMatchChangesController` and the live match changes template treat every substitution whose minute has passed as executed, so the slot was permanently blocked - marked as a substitution that never happened. A dead slot could also not be recycled by injury-driven unplanned substitutions.

## Changes

- `SimulationHelper::checkAndExecuteSubstitutions()`: substitutions that can never be executed anymore are now marked as unreachable (minute 999), reusing the existing mechanism for condition-blocked substitutions. This frees the slot, so the manager can plan another substitution during the live match.
- `SimulationHelper::addUnplannedSubstitution()`: injury-driven unplanned substitutions now prefer replacing unreachable (minute 999) substitutions before sacrificing still valid planned ones.
- Null-safe `strlen()` check for substitutions without a target position (fixes a PHP deprecation).

## Tests

New and extended tests in `websoccer/tests/Unit/SimulationHelperTest.php`:

- planned substitution for a player sent off after his second yellow card is not executed, but frees its slot
- planned substitution for a player with a single yellow card executes normally (documents that a booking alone never blocks a substitution)
- substitution whose bench player already entered the pitch is not executed, but frees its slot
- end-to-end reproduction of the reported scenario: an injury substitution consumes the planned bench player, the skipped substitution frees its slot, and a re-planned substitution finally substitutes the booked player
- unplanned substitutions replace unreachable planned substitutions before still valid future ones
- existing skip tests strengthened with the new slot-freeing contract

Validation: full PHPUnit suite green (1577 tests, 2996 assertions).