### PR TITLE
Prevent unrealistic goalkeeper goal assists (#22)

### DIFF
--- a/websoccer/classes/DefaultSimulationStrategy.class.php
+++ b/websoccer/classes/DefaultSimulationStrategy.class.php
@@ -83,6 +83,14 @@ class DefaultSimulationStrategy implements ISimulationStrategy {
 			return 'passBall';
 		}
 		
+		// player who has just received the ball from his own goaly shall not immediately shoot at the goal.
+		// Otherwise goalkeepers would get unrealistic goal assists (see issue #22).
+		$previousPlayer = $match->getPreviousPlayerWithBall();
+		if ($previousPlayer !== NULL && $previousPlayer->position == PLAYER_POSITION_GOALY
+				&& $previousPlayer->team->id == $player->team->id) {
+			return 'passBall';
+		}
+		
 		// Probability of attack depends on opponent's formation
 		$opponentTeam = SimulationHelper::getOpponentTeam($player, $match);
 		$opponentPosition = $this->_opponentPositions[$player->position];

--- a/websoccer/tests/Unit/DefaultSimulationStrategyTest.php
+++ b/websoccer/tests/Unit/DefaultSimulationStrategyTest.php
@@ -120,6 +120,50 @@ final class DefaultSimulationStrategyTest extends TestCaseBase {
 		$this->assertSame('passBall', $strategy->nextAction($match));
 	}
 
+	/**
+	 * A player who has just received the ball directly from his own goaly must not
+	 * shoot immediately, so that goalies do not get unrealistic goal assists (issue #22).
+	 */
+	public function testNextActionForcesPassAfterBallReceivedFromOwnGoaly(): void {
+		$ws = $this->mockWebsoccer($this->simConfig());
+		\WebSoccer::setInstanceForTesting($ws);
+		$strategy = new DefaultSimulationStrategy($ws);
+		$match = $this->makeFullMatch();
+
+		// goaly passes the ball directly to a striker
+		$goaly = $match->homeTeam->positionsAndPlayers[PLAYER_POSITION_GOALY][0];
+		$match->setPlayerWithBall($goaly);
+		$striker = $match->homeTeam->positionsAndPlayers[PLAYER_POSITION_STRIKER][0];
+		$match->setPlayerWithBall($striker);
+
+		$this->assertSame('passBall', $strategy->nextAction($match));
+	}
+
+	/**
+	 * Receiving the ball from the opponent's goaly (e.g. after intercepting a failed
+	 * clearance) shall not restrict the player's actions.
+	 */
+	public function testNextActionDoesNotForcePassAfterBallReceivedFromOpponentGoaly(): void {
+		$ws = $this->mockWebsoccer($this->simConfig());
+		\WebSoccer::setInstanceForTesting($ws);
+		$strategy = new DefaultSimulationStrategy($ws);
+		$match = $this->makeFullMatch();
+
+		// opponent goaly's failed clearance goes to a striker of the other team
+		$opponentGoaly = $match->guestTeam->positionsAndPlayers[PLAYER_POSITION_GOALY][0];
+		$match->setPlayerWithBall($opponentGoaly);
+		$striker = $match->homeTeam->positionsAndPlayers[PLAYER_POSITION_STRIKER][0];
+		$match->setPlayerWithBall($striker);
+
+		// tackle or shoot must still be possible actions
+		$actions = [];
+		for ($i = 0; $i < 200; $i++) {
+			$actions[$strategy->nextAction($match)] = TRUE;
+		}
+		$this->assertArrayHasKey('tackle', $actions);
+		$this->assertArrayHasKey('shoot', $actions);
+	}
+
 	public function testPassBallReturnsBoolean(): void {
 		$ws = $this->mockWebsoccer($this->simConfig());
 		\WebSoccer::setInstanceForTesting($ws);


### PR DESCRIPTION
Fixes #22

## Problem

Users report that goalkeepers get goal assists far too often (issue #22). In real football, a goalkeeper assist is very rare.

## Root cause

- After every missed shot, free kick or penalty, the ball always goes to the goalkeeper (`DefaultSimulationStrategy::shoot()`).
- A goalkeeper's pass can go directly to a midfielder (about 30%) or even a striker (1%).
- That teammate may then shoot immediately on his next action (`nextAction()`).
- On a goal, the assist is credited to the previous player with the ball (`DefaultSimulationObserver::onGoal()`) - which is then the goalkeeper.

So every "goalkeeper pass -> teammate scores immediately" chain produced an unrealistic goalkeeper assist.

## Fix

`DefaultSimulationStrategy::nextAction()` now forces a pass for any player who has just received the ball directly from his own goalkeeper (7 lines of code):

- No goal attempts (and hence no goals or assists) directly after a goalkeeper's pass.
- A goalkeeper can never be the assist player anymore - neither in player statistics, nor in match reports, nor in youth matches (they all use this strategy).
- Goals after intercepting a failed clearance (ball received from the opponent's goalkeeper) are still possible, since the check applies to the own goalkeeper only.

## Validation

- 2 new unit tests in `DefaultSimulationStrategyTest.php`: forced pass after own goalkeeper's pass; actions still unrestricted after opponent goalkeeper's pass.
- Full PHPUnit suite green: 1579 tests, 2999 assertions.